### PR TITLE
Development Server CSS Placement

### DIFF
--- a/configuration/development.js
+++ b/configuration/development.js
@@ -1,16 +1,16 @@
 const path = require('path');
 
 const {
-    standardPackage: {
-        components: {
-            loaders: { styles: StyleLoaders },
-            plugins: { development: devServerPlugins },
-            profiles: { development: devServerProfile },
-            rules: { file: FileRules }
-        },
-        configuration: { common },
-        environment: { standard: standardEnvironment }
-    }
+  standardPackage: {
+    components: {
+      loaders: { styles: StyleLoaders, devStyleLoader },
+      plugins: { development: devServerPlugins },
+      profiles: { development: devServerProfile },
+      rules: { file: FileRules }
+    },
+    configuration: { common },
+    environment: { standard: standardEnvironment }
+  }
 } = require(path.resolve(__dirname, '..', 'standard-loader'))();
 const { resolver: { requirePackageModule } } = standardEnvironment;
 
@@ -20,31 +20,31 @@ const ReactRefreshWebpackPlugin = requirePackageModule('@pmmmwh/react-refresh-we
 const JavascriptLoaders = require(path.resolve(__dirname, 'loaders', 'scripts'));
 
 const environment = {
-    ...standardEnvironment
+  ...standardEnvironment
 };
 
 environment.scripts.useJsxSyntax = true;
 
 module.exports = merge(
-    common(environment),
-    {
-        ...devServerProfile(environment),
-        module: {
-            rules: [
-                ...FileRules(),
-                ...JavascriptLoaders(environment, true),
-                {
-                    test: /\.(css|scss|sass)$/,
-                    use: [
-                        'style-loader',
-                        ...StyleLoaders(environment, `$asset_root: '${environment.paths.devServerPublic}';`)
-                    ]
-                }
-            ]
-        },
-        plugins: [
-            new ReactRefreshWebpackPlugin(),
-            ...devServerPlugins(environment)
-        ]
-    }
+  common(environment),
+  {
+    ...devServerProfile(environment),
+    module: {
+      rules: [
+        ...FileRules(),
+        ...JavascriptLoaders(environment, true),
+        {
+          test: /\.(css|scss|sass)$/,
+          use: [
+            devStyleLoader(environment),
+            ...StyleLoaders(environment, `$asset_root: '${environment.paths.devServerPublic}';`)
+          ]
+        }
+      ]
+    },
+    plugins: [
+      new ReactRefreshWebpackPlugin(),
+      ...devServerPlugins(environment)
+    ]
+  }
 );


### PR DESCRIPTION
## Description
> As a developer, I need to offer a way to place CSS delivered through JS, in Dev mode, in a consistent location when needed by a project.

## Related Tickets

#16 

## Steps to Validate
1. Install the PR branch version in your project
2. Specify a valid CSS selector (i.e. `#some-id` ) in the KP configuration at `styles.devHeadSelectorInsertBefore`
3. Restart the Dev Server
4. Visit a page which uses the Dev server, verify the styles are in the header (only in the Inspector, not page source)
5. Make a change and verify the new styles are loaded, and injected before the specified element (again in Inspector)

## Deployment Notes

Relies on Kanopi Pack >= 2.1.0
