### PR TITLE
Babel JSX/TSX DOM attribute namespace verification

### DIFF
--- a/configuration/loaders/scripts.js
+++ b/configuration/loaders/scripts.js
@@ -6,26 +6,26 @@
  * @returns Loader rule
  */
 module.exports = (environment, isDevelopment = false) => {
-    const { sourceMaps } = environment;
+  const { sourceMaps } = environment;
 
-    return [
+  return [
+    {
+      test: /\.[j|t]sx?$/,
+      exclude: /node_modules/,
+      use: [
         {
-            test: /\.[j|t]sx?$/,
-            exclude: /node_modules/,
-            use: [
-                {
-                    loader: 'babel-loader',
-                    options: {
-                        presets: [
-                            '@babel/preset-env',
-                            '@babel/preset-typescript',
-                            ['@babel/preset-react', { development: isDevelopment, runtime: 'automatic' }]
-                        ],
-                        plugins: isDevelopment ? ['react-refresh/babel'] : [],
-                        sourceMaps: sourceMaps
-                    }
-                }
-            ]
+          loader: 'babel-loader',
+          options: {
+            presets: [
+              '@babel/preset-env',
+              '@babel/preset-typescript',
+              ['@babel/preset-react', { development: isDevelopment, runtime: 'automatic', throwIfNamespace: false }]
+            ],
+            plugins: isDevelopment ? ['react-refresh/babel'] : [],
+            sourceMaps: sourceMaps
+          }
         }
-    ];
+      ]
+    }
+  ];
 }


### PR DESCRIPTION
## Description

29348589 - Disable JSX/TSX DOM attribute namespace verification

## Steps to Validate

1. Pull the changes into a project which uses JSX/TSX: `npm i github://github.com/kanopi/kanopi-pack-react.git#feature/tw29348589`
2. Start/restart the Development server
3. Make an edit to a JSX/TSX component used in a current entry point, adding an attribute to a DOM element like `x-on:click="alert('Test');"`
4. Verify the element is correctly rendered and the development and production builds don't throw any errors. 
